### PR TITLE
docs(profile): refresh org README for current product positioning

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,130 +1,68 @@
-# Resizes · Developer Platform & Cloud Orchestration
+# Resizes
 
-**Resizes** is a platform that centralises and orchestrates all infrastructure and its critical components: applications, AI agents, APIs, databases, MCPs, and any essential part of the technology stack.
+**Ask your infrastructure anything.**
 
-It is not just another tool.
-Resizes is the place where everything is managed, deployed, and scaled, without the need to constantly switch between providers, consoles, scripts, and environments.
+Conversational visibility and control over cloud infrastructure — plus Platform Engineering that installs and operates Internal Developer Platforms for growing teams.
 
-Our goal is to eliminate the friction between having an idea and bringing it to production, allowing teams to focus on building products and businesses, not fighting with infrastructure.
-
----
-
-## What is Resizes?
-
-Resizes centralises the entire operation of the technology stack on a single platform:
-
-* Applications (frontend, backend, services)
-* Cloud infrastructure
-* Databases
-* APIs and internal services
-* AI agents and automations
-* Platform components and internal systems
-
-Unlike point solutions, Resizes acts as the **orchestration layer** where everything connects, deploys, and scales coherently.
-
-This allows you to:
-
-* Drastically reduce operational complexity
-* Increase delivery speed
-* Gain real visibility into costs, resources, and performance
-* Eliminate technical bottlenecks that slow down growth
-
-The platform absorbs the complexity of operating a modern stack, freeing teams to focus on what really matters: building and improving what is essential to the business.
-
-Resizes eliminates friction between idea and execution.
-No surprises on the bill.
-No artificial limits that block growth.
-No dependencies between multiple disconnected tools.
-
-It is the technology solution that defines the speed at which your company can execute and the security with which it can scale.
+[Website](https://resiz.es) · [Book a demo](https://calendar.app.google/N1s8ZhbScBN7XwTm7) · [Blog](https://blog.resiz.es) · [Discord](https://discord.gg/kC25JjyyKD)
 
 ---
 
-## Company Overview
+## What we build
 
-* **Website:** [https://resiz.es](https://resiz.es)
-* **Phone:** +34 615 384 513
-* **Industry:** Software Development
-* **Company size:** 11–50 employees (12 associated members)
-* **Headquarters:** Gijón, Principality of Asturias, Spain
-* **Founded:** 2024
-
-### Specialties
-
-DevOps, Platform Engineering, AWS, Cloud, GCP, Kubernetes, Infrastructure as Code, Terraform, FinOps, GitOps, Observability, Monitoring, Logging, Security, DevEx, CI/CD y Systems Architecture.
+| Product | What it does |
+| --- | --- |
+| **[Resizes Agentic](https://resiz.es)** | Engineering agents for cloud ops — costs, alerts, architecture questions, and safe proposed actions with human approval. Read-only by default. |
+| **[Resizes Platform](https://resiz.es/services)** | Managed Internal Developer Platforms on your cloud — GitOps, observability, FinOps, security. Typical **20–50% cloud cost reduction**. |
+| **[Resizes AI](https://resizes.ai)** | Business agents SaaS for teams that want AI workflows without building from scratch. |
 
 ---
 
-## Dash — The Resizes Product
+## Why teams choose us
 
-**Dash** is Resizes' flagship product and is evolving into a full-stack platform where teams and developers can create, deploy, and manage everything in one place.
+- **Self-service over ticket queues** — engineers ask natural-language questions and get answers from live infrastructure
+- **Human oversight built in** — agents propose; humans approve; everything is audited
+- **Kubernetes & multi-cloud native** — AWS Partner; AWS, GCP, and Azure support
+- **Platform Engineering expertise** — we install, operate, and transfer knowledge so your team owns day-2
 
-Dash's new direction aims to make the cloud feel simple, connected, and consistent. Instead of jumping between tools or configuring everything from scratch, Dash allows you to:
-
-* Deploy frontends, backends, and databases together
-* Use built-in templates to get projects started faster
-* Manage everything from a unified dashboard
-* Maintain visibility and control with clear usage and resource metrics
-
-This is not just an interface improvement.
-It is the foundation of a complete ecosystem built for speed, collaboration, and a better development experience.
-
-Dash is how Resizes materialises as a product for teams' day-to-day work.
+> *"We used to have two people who understood our cloud setup. Now the whole team can ask and get real answers."*
+> — Fernando Román, CTO at [GreeMko](https://resiz.es)
 
 ---
 
-## Open Source & Public Repositories
+## Open source
 
-In addition to the platform, Resizes maintains and manages multiple public repositories focused on improving infrastructure, automation, platform, and workflows.
+We maintain public tooling for Platform Engineering and automation:
 
-Some examples:
+| Repository | Description |
+| --- | --- |
+| [github-actions](https://github.com/resizes/github-actions) | Reusable GitHub Actions and workflows |
+| [platform-terraform-module-github-oidc-aws-role](https://github.com/resizes/platform-terraform-module-github-oidc-aws-role) | Terraform module for GitHub OIDC → AWS IAM |
+| [kubestronaut](https://github.com/resizes/kubestronaut) | Guide to becoming a Kubestronaut |
+| [monorepo-template](https://github.com/resizes/monorepo-template) | Production-ready monorepo starter |
+| [medusa-starter-default](https://github.com/resizes/medusa-starter-default) | Medusa e-commerce starter |
+| [blog](https://github.com/resizes/blog) | Resizes blog source |
 
-* **Terraform modules** for secure integration between GitHub and AWS (OIDC)
-* Reusable **GitHub Actions and workflows** for clients and internal projects
-* **Project templates** for different stacks, useful for rapid testing and deployment in Dash
-* **Starters** such as Medusa for e-commerce and products
-* **Technical guides** such as Kubestronaut
-* **Public roadmap** for sharing direction and priorities
-
-These repositories are part of Resizes' focus on platform, automation, and continuous improvement of the technical ecosystem.
-
-GitHub: [https://github.com/resizes](https://github.com/resizes)
+Contributions, feedback, and improvements are welcome — see [CONTRIBUTING.md](https://github.com/resizes/.github/blob/main/CONTRIBUTING.md).
 
 ---
 
-## Why Resizes
+## Company
 
-Resizes is not just infrastructure. It is a platform layer that connects people, products, and systems.
-
-It enables teams to:
-
-* Move faster without sacrificing control
-* Reduce complexity without losing flexibility
-* Gain a true view of costs and resources
-* Scale with confidence
-* Build products without operational friction
-
-For growing companies, Resizes acts as the operating system for their technology.
+- **Founded:** 2024 · **HQ:** Gijón, Asturias, Spain
+- **Focus:** Platform Engineering · DevOps · Kubernetes · FinOps · AI agents
+- **Contact:** [hello@resiz.es](mailto:hello@resiz.es)
 
 ---
 
-## Quick Links
+<div align="center">
 
-| Resource        | Link                                                           | Description                    |
-| --------------- | -------------------------------------------------------------- | ------------------------------ |
-| Resizes Website | [https://resiz.es](https://resiz.es)                           | Main company site              |
-| Dash Platform   | [https://dash.resiz.es](https://dash.resiz.es)                 | Product platform               |
-| Documentation   | [https://docs.resiz.es](https://docs.resiz.es)                 | Guides & tutorials             |
-| Blog            | [https://blog.resiz.es](https://blog.resiz.es)                 | News & insights                |
-| GitHub          | [https://github.com/resizes](https://github.com/resizes)       | Open source & platform tooling |
-| Discord         | [https://discord.gg/kC25JjyyKD](https://discord.gg/kC25JjyyKD) | Community & support            |
+[![AWS Partner](https://img.shields.io/badge/AWS-Partner-232F3E?style=flat&logo=amazon-aws&logoColor=white)](https://resiz.es/services)
+[![Website](https://img.shields.io/badge/website-resiz.es-blue?style=flat)](https://resiz.es)
 
----
+**Star us on GitHub if our tooling helps your team.**
 
-## Contributing & Community
+[![GitHub stars](https://img.shields.io/github/stars/resizes?style=social)](https://github.com/resizes)
+[![GitHub followers](https://img.shields.io/github/followers/resizes?style=social)](https://github.com/resizes)
 
-Resizes keeps a significant part of its work open source. Contributions, technical feedback, and improvements to tooling, infrastructure, and platform are welcome.
-
-The focus is on building better tools for modern teams, improving the development experience, and simplifying the operation of complex systems.
-
-
+</div>


### PR DESCRIPTION
## Summary
- Replace outdated Dash-centric org profile with current Resizes Agentic, Platform, and AI messaging
- Align copy with [resiz.es](https://resiz.es) positioning and highlight key open-source repos
- Add customer social proof and cleaner quick links for GitHub visitors

## Test plan
- [x] Review rendered markdown on GitHub org profile after merge

Made with [Cursor](https://cursor.com)